### PR TITLE
Convert Regex objects to static readonly fields with RegexOptions.Compiled and upgrade stability

### DIFF
--- a/WimyGitLib/BranchParser.cs
+++ b/WimyGitLib/BranchParser.cs
@@ -13,23 +13,27 @@ namespace WimyGitLib
 
     public static class BranchParser
     {
+        private static readonly Regex BranchRegex = new Regex(@"([\s\*])\s(\S+)\s+(\S+)\s+(.*)", RegexOptions.Compiled);
+
         public static List<BranchInfo> Parse(List<string> lines)
         {
             List<BranchInfo> output = new List<BranchInfo>();
             foreach (string line in lines)
             {
                 BranchInfo branchInfo = ParseLine(line);
-                output.Add(branchInfo);
+                if (branchInfo != null)
+                {
+                    output.Add(branchInfo);
+                }
             }
             return output;
         }
 
         public static BranchInfo ParseLine(string line)
         {
-            Regex regex = new Regex(@"([\s\*])\s(\S+)\s+(\S+)\s+(.*)");
             BranchInfo branchInfo = new BranchInfo();
 
-            Match match = regex.Match(line);
+            Match match = BranchRegex.Match(line);
             if (match.Success == false)
             {
                 return null;

--- a/WimyGitLib/DownloadParser.cs
+++ b/WimyGitLib/DownloadParser.cs
@@ -11,13 +11,12 @@ namespace WimyGitLib
 
     public class DownloadParser
     {
+        private static readonly Regex VersionRegex = new Regex(@"http.*wimygit/releases/download/v(\d+\.\d+\.\d+)/(.*)", RegexOptions.Compiled);
 
         public static DownloadParserResult GetVersionFromDownloadUrl(string url)
         {
             // "https://github.com/zelon/wimygit/releases/download/v1.0.0/WimyGit-1.0.0.zip"
-            Regex regex = new Regex(@"http.*wimygit/releases/download/v(\d+\.\d+\.\d+)/(.*)");
-
-            Match match = regex.Match(url);
+            Match match = VersionRegex.Match(url);
             if (match.Success == false)
             {
                 return null;

--- a/WimyGitLib/RemoteParser.cs
+++ b/WimyGitLib/RemoteParser.cs
@@ -5,23 +5,27 @@ namespace WimyGitLib
 {
     public class RemoteParser
     {
+        private static readonly Regex RemoteRegex = new Regex(@"(\S+)\s+(\S+)\s+(\S+)", RegexOptions.Compiled);
+
         public static List<RemoteInfo> Parse(List<string> lines)
         {
             List<RemoteInfo> output = new List<RemoteInfo>();
             foreach (string line in lines)
             {
                 RemoteInfo RemoteInfo = ParseLine(line);
-                output.Add(RemoteInfo);
+                if (RemoteInfo != null)
+                {
+                    output.Add(RemoteInfo);
+                }
             }
             return output;
         }
 
         public static RemoteInfo ParseLine(string line)
         {
-            Regex regex = new Regex(@"(\S+)\s+(\S+)\s+(\S+)");
             RemoteInfo RemoteInfo = new RemoteInfo();
 
-            Match match = regex.Match(line);
+            Match match = RemoteRegex.Match(line);
             if (match.Success == false)
             {
                 return null;


### PR DESCRIPTION
- Convert Regex objects to static readonly fields with RegexOptions.Compiled
- Prevents regex recompilation on every method call
- BranchParser: Add null check to prevent adding null entries to list
- RemoteParser: Add null check to prevent adding null entries to list
- DownloadParser: Use static compiled regex for version parsing

Performance impact: For 100+ branches, eliminates repeated regex compilation overhead.