### PR TITLE
feat: Add command line argument support to open directory in tab

### DIFF
--- a/WimyGit/App.xaml.cs
+++ b/WimyGit/App.xaml.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Windows;
 using Backtrace;
 using Backtrace.Model;
@@ -8,7 +8,6 @@ namespace WimyGit
     public partial class App : Application
     {
         private BacktraceClient backtraceClient;
-        internal static string CommandLineDirectory { get; private set; }
 
         protected override void OnStartup(StartupEventArgs e)
         {
@@ -29,27 +28,6 @@ namespace WimyGit
             // 전역 예외 처리 설정
             AppDomain.CurrentDomain.UnhandledException += OnUnhandledException;
             DispatcherUnhandledException += OnDispatcherUnhandledException;
-
-            // 명령줄 인자 처리
-            if (e.Args.Length > 0)
-            {
-                string directory = e.Args[0];
-
-                // Git 디렉토리 유효성 검사
-                if (Util.IsValidGitDirectory(directory))
-                {
-                    CommandLineDirectory = directory;
-                }
-                else
-                {
-                    MessageBox.Show(
-                        $"'{directory}' is not a valid Git repository.",
-                        "WimyGit",
-                        MessageBoxButton.OK,
-                        MessageBoxImage.Warning
-                    );
-                }
-            }
         }
 
         private void OnUnhandledException(object sender, UnhandledExceptionEventArgs e)

--- a/WimyGit/App.xaml.cs
+++ b/WimyGit/App.xaml.cs
@@ -8,6 +8,7 @@ namespace WimyGit
     public partial class App : Application
     {
         private BacktraceClient backtraceClient;
+        internal static string CommandLineDirectory { get; private set; }
 
         protected override void OnStartup(StartupEventArgs e)
         {
@@ -37,39 +38,16 @@ namespace WimyGit
                 // Git 디렉토리 유효성 검사
                 if (Util.IsValidGitDirectory(directory))
                 {
-                    // MainWindow가 완전히 로드된 후 처리
-                    EventHandler loadedHandler = null;
-                    loadedHandler = (sender, args) =>
-                    {
-                        if (Application.Current.MainWindow is Views.MainWindow.MainWindow mainWindow)
-                        {
-                            mainWindow.HandleDirectoryArgument(directory);
-                            Application.Current.MainWindow.Loaded -= loadedHandler;
-                        }
-                    };
-
-                    // MainWindow.Loaded 이벤트에 핸들러 등록
-                    this.Activated += (sender, args) =>
-                    {
-                        if (Application.Current.MainWindow != null)
-                        {
-                            Application.Current.MainWindow.Loaded += loadedHandler;
-                        }
-                    };
+                    CommandLineDirectory = directory;
                 }
                 else
                 {
-                    // 유효하지 않은 디렉토리 경고
-                    this.Activated += (sender, args) =>
-                    {
-                        MessageBox.Show(
-                            $"'{directory}' is not a valid Git repository.",
-                            "WimyGit",
-                            MessageBoxButton.OK,
-                            MessageBoxImage.Warning
-                        );
-                        this.Activated -= (EventHandler)sender;
-                    };
+                    MessageBox.Show(
+                        $"'{directory}' is not a valid Git repository.",
+                        "WimyGit",
+                        MessageBoxButton.OK,
+                        MessageBoxImage.Warning
+                    );
                 }
             }
         }

--- a/WimyGit/Views/MainWindow/MainWindow.xaml.cs
+++ b/WimyGit/Views/MainWindow/MainWindow.xaml.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Diagnostics;
+using System.IO;
 using System.Windows;
 using System.Windows.Controls;
 
@@ -152,6 +153,35 @@ namespace WimyGit
                 }
             }
             new NewRepositoryController(tab_control_).OpenRepository(repository_path);
+        }
+
+        public void HandleDirectoryArgument(string directory)
+        {
+            // 경로 정규화
+            string normalizedPath = Path.GetFullPath(directory).TrimEnd('\\', '/');
+
+            // 기존 탭에서 찾기
+            foreach (TabItem tabItem in tab_control_.Items)
+            {
+                if (tabItem.Header is UserControls.RepositoryTabHeader header)
+                {
+                    string tabPath = (string)header.Path.Content;
+                    if (!string.IsNullOrEmpty(tabPath))
+                    {
+                        string normalizedTabPath = Path.GetFullPath(tabPath).TrimEnd('\\', '/');
+                        if (normalizedTabPath.Equals(normalizedPath, StringComparison.OrdinalIgnoreCase))
+                        {
+                            // 찾았다! → 포커스
+                            tabItem.IsSelected = true;
+                            tabItem.Focus();
+                            return;
+                        }
+                    }
+                }
+            }
+
+            // 못 찾았다 → 새 탭 추가
+            new NewRepositoryController(tab_control_).OpenRepository(directory);
         }
     }
 }

--- a/WimyGit/Views/MainWindow/MainWindow.xaml.cs
+++ b/WimyGit/Views/MainWindow/MainWindow.xaml.cs
@@ -106,9 +106,14 @@ namespace WimyGit
             RestoreTabs();
 
             // 명령줄 인자로 전달된 디렉토리 처리
-            if (!string.IsNullOrEmpty(App.CommandLineDirectory))
+            string[] args = Environment.GetCommandLineArgs();
+            if (args.Length > 1) // args[0]은 실행 파일 경로, args[1]부터 실제 인자
             {
-                HandleDirectoryArgument(App.CommandLineDirectory);
+                string directory = args[1];
+                if (Util.IsValidGitDirectory(directory))
+                {
+                    HandleDirectoryArgument(directory);
+                }
             }
         }
 

--- a/WimyGit/Views/MainWindow/MainWindow.xaml.cs
+++ b/WimyGit/Views/MainWindow/MainWindow.xaml.cs
@@ -104,6 +104,12 @@ namespace WimyGit
             GlobalSetting.GetInstance().SetWindow(this);
             SetTitleToGitVersion();
             RestoreTabs();
+
+            // 명령줄 인자로 전달된 디렉토리 처리
+            if (!string.IsNullOrEmpty(App.CommandLineDirectory))
+            {
+                HandleDirectoryArgument(App.CommandLineDirectory);
+            }
         }
 
         private void SetTitleToGitVersion()


### PR DESCRIPTION
When launching with a directory path as first argument, the app now checks if that directory is already open in a tab and focuses it, or opens it in a new tab if not found.