### PR TITLE
fix: cherry-pick now refreshes repo state on conflict

### DIFF
--- a/wimygit-tauri/src/components/tabs/HistoryTab.tsx
+++ b/wimygit-tauri/src/components/tabs/HistoryTab.tsx
@@ -94,7 +94,12 @@ function ContextMenu({ x, y, commit, repoPath, onClose, onRefresh }: ContextMenu
         try { await invoke("run_git_simple", { args: ["tag", name.trim(), commit.hash], cwd: repoPath }); onRefresh(); }
         catch (e) { alert(String(e)); }
     }},
-    { label: "Cherry-pick",       action: () => run(["cherry-pick", commit.hash]) },
+    { label: "Cherry-pick",       action: async () => {
+        onClose();
+        try { await invoke("run_git", { args: ["cherry-pick", commit.hash], cwd: repoPath }); }
+        catch { /* run_git only fails if git is not found; conflicts are non-throwing */ }
+        onRefresh();
+    }},
     { label: "──", action: () => {} },
     { label: "Reset Soft",        action: () => { if (confirm(`Reset soft to ${commit.short_hash}?`)) run(["reset", "--soft", commit.hash]); } },
     { label: "Reset Mixed",       action: () => { if (confirm(`Reset mixed to ${commit.short_hash}?`)) run(["reset", "--mixed", commit.hash]); } },


### PR DESCRIPTION
When git cherry-pick encounters conflicts it exits with code 1.
The previous run_git_simple call would throw, skipping onRefresh(),
so the CHERRY-PICK state banner (Continue/Abort) never appeared.

Switching to run_git (which never throws on non-zero exit) and always
calling onRefresh() ensures the RepoStateBanner shows up correctly
when a conflict needs user resolution.

https://claude.ai/code/session_01TkJXjMrxrM62qpaUCvf9Wr