### PR TITLE
feat: add auto-fetch with configurable interval

### DIFF
--- a/wimygit-tauri/src/App.tsx
+++ b/wimygit-tauri/src/App.tsx
@@ -52,6 +52,7 @@ interface RepoTabState {
   repoName: string;
   activeTab: string;
   refreshKey: number;
+  silentRefreshKey: number;
 }
 
 const STORAGE_KEY = "repoTabs_v2";
@@ -120,6 +121,7 @@ function App() {
       repoName: s.repoName,
       activeTab: "pending",
       refreshKey: 0,
+      silentRefreshKey: 0,
     }));
     setRepoTabs(tabs);
     const lastActive = localStorage.getItem("activeRepoId");
@@ -164,6 +166,14 @@ function App() {
   const handleRefresh = useCallback(() => {
     updateActiveRepo((t) => ({ refreshKey: t.refreshKey + 1 }));
   }, [updateActiveRepo]);
+
+  const handleSilentRefresh = useCallback(() => {
+    setRepoTabs((prev) =>
+      prev.map((t) =>
+        t.id === activeRepoId ? { ...t, silentRefreshKey: t.silentRefreshKey + 1 } : t
+      )
+    );
+  }, [activeRepoId]);
 
   const handleAfterPush = useCallback(async (repoPath: string) => {
     try {
@@ -301,6 +311,7 @@ function App() {
           repoName: repoNameFromPath(root),
           activeTab: "pending",
           refreshKey: 0,
+          silentRefreshKey: 0,
         };
 
         setRepoTabs((prev) => {
@@ -442,6 +453,7 @@ function App() {
         onTimeLapse={() => setShowTimeLapse(true)}
         autoFetchSettings={autoFetchSettings}
         onAutoFetchSettingsChange={handleAutoFetchSettingsChange}
+        onSilentRefresh={handleSilentRefresh}
       />
 
       {/* Body: left sidebar + main content */}
@@ -479,6 +491,7 @@ function App() {
             <PendingTab
               repoPath={activeRepo.repoPath}
               refreshKey={activeRepo.refreshKey}
+              silentRefreshKey={activeRepo.silentRefreshKey}
               onFilePreview={(filename, staged) => { setSelectedDiff(null); setPendingFilePreview({ filename, staged }); }}
               onLfsLockCountChange={setLfsLockCount}
               onShowInWorkspaceFile={(absolutePath) => {
@@ -503,6 +516,7 @@ function App() {
                 repoPath={activeRepo.repoPath}
                 filePath={selectedFilePath}
                 refreshKey={activeRepo.refreshKey}
+                silentRefreshKey={activeRepo.silentRefreshKey}
                 onRefresh={handleRefresh}
                 onFileSelect={setSelectedDiff}
                 onClearPath={() => setSelectedFilePath(null)}
@@ -524,6 +538,7 @@ function App() {
               <BranchTab
                 repoPath={activeRepo.repoPath}
                 refreshKey={activeRepo.refreshKey}
+                silentRefreshKey={activeRepo.silentRefreshKey}
                 onRefresh={handleRefresh}
               />
             )}

--- a/wimygit-tauri/src/App.tsx
+++ b/wimygit-tauri/src/App.tsx
@@ -30,6 +30,11 @@ import {
   type LfsLock,
 } from "./lib";
 import { LfsUnlockModal } from "./components/shared/LfsUnlockModal";
+import {
+  loadAutoFetchSettings,
+  saveAutoFetchSettings,
+  type AutoFetchSettings,
+} from "./hooks/useAutoFetch";
 
 const BASE_INNER_TABS = [
   { id: "pending", label: "Pending Changes" },
@@ -90,6 +95,7 @@ function App() {
   const [lfsLockCount, setLfsLockCount] = useState(0);
   const [worktreeCount, setWorktreeCount] = useState(0);
   const [showPluginModal, setShowPluginModal] = useState(false);
+  const [autoFetchSettings, setAutoFetchSettings] = useState<AutoFetchSettings>(loadAutoFetchSettings);
   const [lfsUnlockConfirm, setLfsUnlockConfirm] = useState<{
     repoPath: string;
     locks: LfsLock[];
@@ -170,6 +176,11 @@ function App() {
     } catch {
       // LFS not available or network error — silently skip
     }
+  }, []);
+
+  const handleAutoFetchSettingsChange = useCallback((settings: AutoFetchSettings) => {
+    saveAutoFetchSettings(settings);
+    setAutoFetchSettings(settings);
   }, []);
 
   const handleLfsUnlockConfirm = useCallback(async () => {
@@ -429,6 +440,8 @@ function App() {
         plugins={plugins}
         selectedFilePath={selectedFilePath}
         onTimeLapse={() => setShowTimeLapse(true)}
+        autoFetchSettings={autoFetchSettings}
+        onAutoFetchSettingsChange={handleAutoFetchSettingsChange}
       />
 
       {/* Body: left sidebar + main content */}

--- a/wimygit-tauri/src/components/layout/Header.tsx
+++ b/wimygit-tauri/src/components/layout/Header.tsx
@@ -25,6 +25,7 @@ interface HeaderProps {
   onTimeLapse?: () => void;
   autoFetchSettings: AutoFetchSettings;
   onAutoFetchSettingsChange: (settings: AutoFetchSettings) => void;
+  onSilentRefresh: () => void;
 }
 
 type BusyKey =
@@ -212,7 +213,7 @@ function Sep() {
 
 // ─── Header ───────────────────────────────────────────────────────────────────
 
-export function Header({ repoPath, refreshKey, onRefresh, onPushSuccess, plugins = [], selectedFilePath, onTimeLapse, autoFetchSettings, onAutoFetchSettingsChange }: HeaderProps) {
+export function Header({ repoPath, refreshKey, onRefresh, onPushSuccess, plugins = [], selectedFilePath, onTimeLapse, autoFetchSettings, onAutoFetchSettingsChange, onSilentRefresh }: HeaderProps) {
   const [currentBranch, setCurrentBranch] = useState<string>("");
   const [repoName, setRepoName] = useState<string>("");
   const [author, setAuthor] = useState<{ name: string; email: string } | null>(null);
@@ -258,8 +259,8 @@ export function Header({ repoPath, refreshKey, onRefresh, onPushSuccess, plugins
 
   const handleAutoFetch = useCallback(async () => {
     await gitFetchAll(repoPath);
-    onRefresh();
-  }, [repoPath, onRefresh]);
+    onSilentRefresh();
+  }, [repoPath, onSilentRefresh]);
 
   const { lastFetchedAt, nextFetchIn, isFetching: isAutoFetching } = useAutoFetch({
     settings: autoFetchSettings,

--- a/wimygit-tauri/src/components/layout/Header.tsx
+++ b/wimygit-tauri/src/components/layout/Header.tsx
@@ -12,6 +12,8 @@ import {
   type PluginInfo,
 } from "../../lib";
 import { PluginButtons } from "./PluginButtons";
+import { useAutoFetch, type AutoFetchSettings } from "../../hooks/useAutoFetch";
+import { AutoFetchIndicator } from "../shared/AutoFetchIndicator";
 
 interface HeaderProps {
   repoPath: string;
@@ -21,6 +23,8 @@ interface HeaderProps {
   plugins?: PluginInfo[];
   selectedFilePath?: string | null;
   onTimeLapse?: () => void;
+  autoFetchSettings: AutoFetchSettings;
+  onAutoFetchSettingsChange: (settings: AutoFetchSettings) => void;
 }
 
 type BusyKey =
@@ -208,7 +212,7 @@ function Sep() {
 
 // ─── Header ───────────────────────────────────────────────────────────────────
 
-export function Header({ repoPath, refreshKey, onRefresh, onPushSuccess, plugins = [], selectedFilePath, onTimeLapse }: HeaderProps) {
+export function Header({ repoPath, refreshKey, onRefresh, onPushSuccess, plugins = [], selectedFilePath, onTimeLapse, autoFetchSettings, onAutoFetchSettingsChange }: HeaderProps) {
   const [currentBranch, setCurrentBranch] = useState<string>("");
   const [repoName, setRepoName] = useState<string>("");
   const [author, setAuthor] = useState<{ name: string; email: string } | null>(null);
@@ -251,6 +255,18 @@ export function Header({ repoPath, refreshKey, onRefresh, onPushSuccess, plugins
   }, [onRefresh, onPushSuccess]);
 
   const isDisabled = busy !== null;
+
+  const handleAutoFetch = useCallback(async () => {
+    await gitFetchAll(repoPath);
+    onRefresh();
+  }, [repoPath, onRefresh]);
+
+  const { lastFetchedAt, nextFetchIn, isFetching: isAutoFetching } = useAutoFetch({
+    settings: autoFetchSettings,
+    repoPath,
+    isBusy: busy !== null,
+    onFetch: handleAutoFetch,
+  });
 
   // ── Push dropdown items ──────────────────────────────────────────────────
 
@@ -330,6 +346,15 @@ export function Header({ repoPath, refreshKey, onRefresh, onPushSuccess, plugins
           isBusy={busy === "fetchAll"}
           disabled={isDisabled}
           onClick={() => run("fetchAll", () => gitFetchAll(repoPath), true)}
+        />
+
+        {/* ── 3b. Auto Fetch indicator ── */}
+        <AutoFetchIndicator
+          settings={autoFetchSettings}
+          nextFetchIn={nextFetchIn}
+          isFetching={isAutoFetching}
+          lastFetchedAt={lastFetchedAt}
+          onChange={onAutoFetchSettingsChange}
         />
 
         {/* ── 4. Pull ── */}

--- a/wimygit-tauri/src/components/shared/AutoFetchIndicator.tsx
+++ b/wimygit-tauri/src/components/shared/AutoFetchIndicator.tsx
@@ -1,0 +1,112 @@
+import { useState, useRef, useEffect } from "react";
+import { AUTO_FETCH_INTERVALS, type AutoFetchSettings } from "../../hooks/useAutoFetch";
+
+interface AutoFetchIndicatorProps {
+  settings: AutoFetchSettings;
+  nextFetchIn: number;
+  isFetching: boolean;
+  lastFetchedAt: Date | null;
+  onChange: (settings: AutoFetchSettings) => void;
+}
+
+function formatCountdown(seconds: number): string {
+  const m = Math.floor(seconds / 60);
+  const s = seconds % 60;
+  return `${m}:${String(s).padStart(2, "0")}`;
+}
+
+export function AutoFetchIndicator({
+  settings,
+  nextFetchIn,
+  isFetching,
+  lastFetchedAt,
+  onChange,
+}: AutoFetchIndicatorProps) {
+  const [open, setOpen] = useState(false);
+  const wrapRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!open) return;
+    const handler = (e: MouseEvent) => {
+      if (wrapRef.current && !wrapRef.current.contains(e.target as Node)) {
+        setOpen(false);
+      }
+    };
+    document.addEventListener("mousedown", handler);
+    return () => document.removeEventListener("mousedown", handler);
+  }, [open]);
+
+  const label = settings.enabled
+    ? isFetching
+      ? "Fetching…"
+      : formatCountdown(nextFetchIn)
+    : "Auto";
+
+  const tooltip = settings.enabled
+    ? `Auto-fetch every ${settings.intervalMinutes}m — click to configure`
+    : "Auto-fetch disabled — click to enable";
+
+  return (
+    <div ref={wrapRef} className="relative shrink-0">
+      <button
+        onClick={() => setOpen((v) => !v)}
+        title={tooltip}
+        className={`flex items-center gap-1 px-2 py-1 h-full text-[10px] rounded border transition-colors ${
+          settings.enabled
+            ? "bg-green-50 dark:bg-green-900/30 border-green-300 dark:border-green-700 text-green-700 dark:text-green-300"
+            : "bg-gray-50 dark:bg-gray-800 border-gray-200 dark:border-gray-700 text-gray-400 dark:text-gray-500"
+        }`}
+      >
+        <span
+          className={isFetching ? "inline-block animate-spin" : ""}
+          style={{ display: "inline-block" }}
+        >
+          ↺
+        </span>
+        <span className="tabular-nums">{label}</span>
+      </button>
+
+      {open && (
+        <div className="absolute left-0 top-full mt-0.5 z-50 w-52 bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded shadow-lg p-3">
+          <div className="text-xs font-semibold text-gray-700 dark:text-gray-300 mb-2">
+            Auto Fetch
+          </div>
+
+          <label className="flex items-center gap-2 mb-3 cursor-pointer select-none">
+            <input
+              type="checkbox"
+              checked={settings.enabled}
+              onChange={(e) => onChange({ ...settings, enabled: e.target.checked })}
+              className="w-3.5 h-3.5 accent-blue-500"
+            />
+            <span className="text-xs text-gray-600 dark:text-gray-400">Enable auto-fetch</span>
+          </label>
+
+          <div className="text-[10px] text-gray-500 dark:text-gray-500 mb-1.5">Interval</div>
+          <div className="flex flex-wrap gap-1 mb-2">
+            {AUTO_FETCH_INTERVALS.map((m) => (
+              <button
+                key={m}
+                onClick={() => onChange({ ...settings, intervalMinutes: m })}
+                disabled={!settings.enabled}
+                className={`px-2 py-0.5 text-[10px] rounded border transition-colors disabled:opacity-40 ${
+                  settings.intervalMinutes === m
+                    ? "bg-blue-500 border-blue-500 text-white"
+                    : "bg-white dark:bg-gray-700 border-gray-200 dark:border-gray-600 text-gray-600 dark:text-gray-400 hover:bg-gray-50 dark:hover:bg-gray-600"
+                }`}
+              >
+                {m}m
+              </button>
+            ))}
+          </div>
+
+          {lastFetchedAt && (
+            <div className="text-[10px] text-gray-400 dark:text-gray-500">
+              Last fetched: {lastFetchedAt.toLocaleTimeString()}
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/wimygit-tauri/src/components/tabs/BranchTab.tsx
+++ b/wimygit-tauri/src/components/tabs/BranchTab.tsx
@@ -12,10 +12,11 @@ import {
 interface BranchTabProps {
   repoPath: string;
   refreshKey: number;
+  silentRefreshKey?: number;
   onRefresh: () => void;
 }
 
-export function BranchTab({ repoPath, refreshKey, onRefresh }: BranchTabProps) {
+export function BranchTab({ repoPath, refreshKey, silentRefreshKey, onRefresh }: BranchTabProps) {
   const [branches, setBranches] = useState<BranchInfo[]>([]);
   const [currentBranch, setCurrentBranch] = useState<string>("");
   const [loading, setLoading] = useState(true);
@@ -50,6 +51,26 @@ export function BranchTab({ repoPath, refreshKey, onRefresh }: BranchTabProps) {
     fetchBranches();
     return () => { fetchGenRef.current++; };
   }, [repoPath, refreshKey]);
+
+  const silentFetchGenRef = useRef(0);
+
+  useEffect(() => {
+    if (!silentRefreshKey || !repoPath) return;
+    const gen = ++silentFetchGenRef.current;
+    (async () => {
+      try {
+        const [branchList, current] = await Promise.all([
+          getBranches(repoPath),
+          getCurrentBranch(repoPath),
+        ]);
+        if (gen !== silentFetchGenRef.current) return;
+        setBranches(branchList);
+        setCurrentBranch(current);
+      } catch {
+        // silent refresh errors are ignored
+      }
+    })();
+  }, [repoPath, silentRefreshKey]);
 
   const handleCheckout = async (branchName: string) => {
     try {

--- a/wimygit-tauri/src/components/tabs/HistoryTab.tsx
+++ b/wimygit-tauri/src/components/tabs/HistoryTab.tsx
@@ -19,6 +19,7 @@ interface HistoryTabProps {
   repoPath: string;
   filePath?: string | null;
   refreshKey: number;
+  silentRefreshKey?: number;
   onRefresh: () => void;
   onFileSelect?: (info: SelectedDiffInfo) => void;
   onClearPath?: () => void;
@@ -240,7 +241,7 @@ function FileContextMenu({ x, y, absolutePath, onClose, onShowInWorkspace, onSho
 
 const PAGE_SIZE = 100;
 
-export function HistoryTab({ repoPath, filePath, refreshKey, onRefresh, onFileSelect, onClearPath, onShowInWorkspace, onShowInWorkspaceFile, onShowInHistoryFile }: HistoryTabProps) {
+export function HistoryTab({ repoPath, filePath, refreshKey, silentRefreshKey, onRefresh, onFileSelect, onClearPath, onShowInWorkspace, onShowInWorkspaceFile, onShowInHistoryFile }: HistoryTabProps) {
   const [commits, setCommits] = useState<CommitInfo[]>([]);
   const [loading, setLoading] = useState(true);
   const [loadingMore, setLoadingMore] = useState(false);
@@ -294,6 +295,23 @@ export function HistoryTab({ repoPath, filePath, refreshKey, onRefresh, onFileSe
     loadHistory(0);
     return () => { loadHistoryGenRef.current++; };
   }, [repoPath, refreshKey, loadHistory]);
+
+  const silentHistoryGenRef = useRef(0);
+
+  useEffect(() => {
+    if (!silentRefreshKey || !repoPath) return;
+    const gen = ++silentHistoryGenRef.current;
+    (async () => {
+      try {
+        const result = await getHistory(repoPath, filePath ?? "", 0, PAGE_SIZE, allBranches, searchQuery || undefined);
+        if (gen !== silentHistoryGenRef.current) return;
+        setCommits(result);
+        setHasMore(result.length === PAGE_SIZE);
+      } catch {
+        // silent refresh errors are ignored
+      }
+    })();
+  }, [repoPath, silentRefreshKey]);
 
   useEffect(() => {
     if (!repoPath) return;

--- a/wimygit-tauri/src/components/tabs/PendingTab.tsx
+++ b/wimygit-tauri/src/components/tabs/PendingTab.tsx
@@ -55,6 +55,7 @@ async function generateAiCommitMessage(stagedDiff: string, apiKey: string): Prom
 interface PendingTabProps {
   repoPath: string;
   refreshKey: number;
+  silentRefreshKey?: number;
   onFilePreview?: (filename: string, staged: boolean, isUntracked?: boolean) => void;
   onLfsLockCountChange?: (count: number) => void;
   onShowInWorkspaceFile?: (absolutePath: string) => void;
@@ -538,7 +539,7 @@ function SectionHeader({ label, count, action }: SectionHeaderProps) {
 
 // ─── Main component ───────────────────────────────────────────────────────────
 
-export function PendingTab({ repoPath, refreshKey, onFilePreview, onLfsLockCountChange, onShowInWorkspaceFile, onShowInHistoryFile }: PendingTabProps) {
+export function PendingTab({ repoPath, refreshKey, silentRefreshKey, onFilePreview, onLfsLockCountChange, onShowInWorkspaceFile, onShowInHistoryFile }: PendingTabProps) {
   const [status, setStatus] = useState<GitStatus | null>(null);
   const [syncStatus, setSyncStatus] = useState<SyncStatus | null>(null);
   const [loading, setLoading] = useState(true);
@@ -602,6 +603,35 @@ export function PendingTab({ repoPath, refreshKey, onFilePreview, onLfsLockCount
     setSelectedUnstaged(new Set());
     return () => { fetchGenRef.current++; };
   }, [repoPath, refreshKey]);
+
+  const silentFetchGenRef = useRef(0);
+
+  useEffect(() => {
+    if (!silentRefreshKey || !repoPath) return;
+    const gen = ++silentFetchGenRef.current;
+    (async () => {
+      try {
+        const [result, lockableExts, sync] = await Promise.all([
+          getGitStatus(repoPath),
+          getLfsLockableExtensions(repoPath).catch(() => [] as string[]),
+          getSyncStatus(repoPath),
+        ]);
+        if (gen !== silentFetchGenRef.current) return;
+        const hasLockable = lockableExts.length > 0;
+        const locks = hasLockable
+          ? await getLfsLocks(repoPath).catch(() => [] as LfsLock[])
+          : [];
+        if (gen !== silentFetchGenRef.current) return;
+        setStatus(result);
+        setSyncStatus(sync);
+        setLfsLocks(locks);
+        setHasLfsLockable(hasLockable);
+        onLfsLockCountChange?.(locks.length);
+      } catch {
+        // silent refresh errors are ignored to avoid disrupting the user
+      }
+    })();
+  }, [repoPath, silentRefreshKey]);
 
   // ── File actions ──────────────────────────────────────────────────────────
 

--- a/wimygit-tauri/src/hooks/useAutoFetch.ts
+++ b/wimygit-tauri/src/hooks/useAutoFetch.ts
@@ -1,0 +1,107 @@
+import { useState, useEffect, useRef } from "react";
+
+export interface AutoFetchSettings {
+  enabled: boolean;
+  intervalMinutes: number;
+}
+
+export const AUTO_FETCH_STORAGE_KEY = "wimygit_auto_fetch";
+export const AUTO_FETCH_INTERVALS = [1, 2, 5, 10, 15, 30] as const;
+
+export function loadAutoFetchSettings(): AutoFetchSettings {
+  try {
+    const raw = localStorage.getItem(AUTO_FETCH_STORAGE_KEY);
+    if (raw) {
+      const parsed = JSON.parse(raw);
+      return {
+        enabled: Boolean(parsed.enabled),
+        intervalMinutes: (AUTO_FETCH_INTERVALS as readonly number[]).includes(parsed.intervalMinutes)
+          ? parsed.intervalMinutes
+          : 5,
+      };
+    }
+  } catch {
+    // ignore
+  }
+  return { enabled: false, intervalMinutes: 5 };
+}
+
+export function saveAutoFetchSettings(settings: AutoFetchSettings): void {
+  localStorage.setItem(AUTO_FETCH_STORAGE_KEY, JSON.stringify(settings));
+}
+
+interface UseAutoFetchOptions {
+  settings: AutoFetchSettings;
+  repoPath: string | null;
+  isBusy: boolean;
+  onFetch: () => Promise<void>;
+}
+
+export interface UseAutoFetchResult {
+  lastFetchedAt: Date | null;
+  nextFetchIn: number;
+  isFetching: boolean;
+}
+
+export function useAutoFetch({
+  settings,
+  repoPath,
+  isBusy,
+  onFetch,
+}: UseAutoFetchOptions): UseAutoFetchResult {
+  const [lastFetchedAt, setLastFetchedAt] = useState<Date | null>(null);
+  const [nextFetchIn, setNextFetchIn] = useState(settings.intervalMinutes * 60);
+  const [isFetching, setIsFetching] = useState(false);
+
+  const nextFetchInRef = useRef(settings.intervalMinutes * 60);
+  const isBusyRef = useRef(isBusy);
+  const isFetchingRef = useRef(false);
+  const onFetchRef = useRef(onFetch);
+  const settingsRef = useRef(settings);
+
+  useEffect(() => { isBusyRef.current = isBusy; }, [isBusy]);
+  useEffect(() => { onFetchRef.current = onFetch; }, [onFetch]);
+  useEffect(() => { settingsRef.current = settings; }, [settings]);
+
+  // Reset countdown when interval, enabled state, or repo changes
+  useEffect(() => {
+    const secs = settings.intervalMinutes * 60;
+    nextFetchInRef.current = secs;
+    setNextFetchIn(secs);
+  }, [settings.intervalMinutes, settings.enabled, repoPath]);
+
+  useEffect(() => {
+    if (!settings.enabled || !repoPath) return;
+
+    const tick = setInterval(async () => {
+      nextFetchInRef.current -= 1;
+      setNextFetchIn(nextFetchInRef.current);
+
+      if (nextFetchInRef.current > 0) return;
+
+      // Reset timer immediately before fetching
+      const secs = settingsRef.current.intervalMinutes * 60;
+      nextFetchInRef.current = secs;
+      setNextFetchIn(secs);
+
+      // Skip if a manual operation or previous auto-fetch is in progress
+      if (isBusyRef.current || isFetchingRef.current) return;
+
+      isFetchingRef.current = true;
+      setIsFetching(true);
+      try {
+        await onFetchRef.current();
+        setLastFetchedAt(new Date());
+      } catch {
+        // Errors are logged via the git-log event system
+      } finally {
+        isFetchingRef.current = false;
+        setIsFetching(false);
+      }
+    }, 1000);
+
+    return () => clearInterval(tick);
+  }, [settings.enabled, repoPath]);
+
+  return { lastFetchedAt, nextFetchIn, isFetching };
+}


### PR DESCRIPTION
Adds a background auto-fetch timer that periodically runs git fetch --all.
- New useAutoFetch hook with 1-second countdown and skip logic when busy
- AutoFetchIndicator button shows countdown (M:SS) or fetching state
- Settings dropdown: enable/disable + interval (1/2/5/10/15/30 min)
- Settings persisted to localStorage; resets countdown on repo switch
- Auto-fetch skips silently if a manual operation is in progress

https://claude.ai/code/session_01GwxvFwJmVysaUZgUHzPFNy